### PR TITLE
Additional ROS2 Dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclpy REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -49,11 +50,11 @@ include_directories(
 
 
 add_executable(ahrs_driver_node src/ahrs_driver.cpp src/crc_table.cpp)
-ament_target_dependencies(ahrs_driver_node rclcpp rclpy  std_msgs  sensor_msgs  serial tf2_ros tf2)
+ament_target_dependencies(ahrs_driver_node rclcpp rclpy  std_msgs  sensor_msgs  serial tf2_ros tf2_geometry_msgs tf2)
 
 
 add_executable(imu_tf_node src/imu_tf.cpp)
-ament_target_dependencies(imu_tf_node rclcpp rclpy std_msgs sensor_msgs serial tf2_ros tf2)
+ament_target_dependencies(imu_tf_node rclcpp rclpy std_msgs sensor_msgs serial tf2_ros tf2_geometry_msgs tf2)
 
 # find_package(Boost 1.55.0 REQUIRED COMPONENTS system filesystem)
 # include_directories(ahrs_driver_node ${Boost_INCLOUDE_DIRS})

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
   <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Thanks for the useful package! There were additional dependencies that I needed to add to be able to compile and run the ROS2 branch, and I wanted to offer those fixes to you.

As you'll see, the updates are just adding `tf2_ros` and `tf2_geometry_msgs` to the package dependencies.